### PR TITLE
Fixed cim vs wmi command, Add foghostid param option for reset-hostencryption, and add more examples to docs

### DIFF
--- a/FogApi/Public/Approve-FogPendingMac.ps1
+++ b/FogApi/Public/Approve-FogPendingMac.ps1
@@ -19,8 +19,7 @@ function Approve-FogPendingMac {
     This gets the first mac to approve in the list of pending macs and approves it
     
     .EXAMPLE
-    $pendingMac = (Get-PendingMacsForHost -hostID 123) | Where-object mac -eq "01:23:45:67:89"
-    Approve-FogPendingMac -macObject $pendingMac
+    $pendingMac = (Get-PendingMacsForHost -hostID 123) | Where-object mac -eq "01:23:45:67:89"; Approve-FogPendingMac -macObject $pendingMac
 
     Approve the specific pending mac address of "01:23:45:67:89" after finding it pending for a host of the id 123
 

--- a/FogApi/Public/Deny-FogPendingMac.ps1
+++ b/FogApi/Public/Deny-FogPendingMac.ps1
@@ -16,8 +16,7 @@ function Deny-FogPendingMac {
     This gets the first mac to approve in the list of pending macs and approves it
 
     .EXAMPLE
-    $pendingMac = (Get-PendingMacsForHost -hostID 123) | Where-object mac -eq "01:23:45:67:89"
-    Deny-FogPendingMac -macObject $pendingMac
+    $pendingMac = (Get-PendingMacsForHost -hostID 123) | Where-object mac -eq "01:23:45:67:89"; Deny-FogPendingMac -macObject $pendingMac
 
     Deny the specific pending mac of "01:23:45:67:89" after finding it pending for a host of the id 123    
 

--- a/FogApi/Public/Disable-FogApiHTTPS.ps1
+++ b/FogApi/Public/Disable-FogApiHTTPS.ps1
@@ -5,6 +5,11 @@ function Disable-FogApiHTTPS {
     
     .DESCRIPTION
     Prepends http to the fogserver property of fog server settings
+
+    .EXAMPLE
+    Disable-FogApiHTTPS
+
+    This example will enforce http in the url used in all api calls by prepending http to the fogserver property of fog server settings
     
     #>
     [CmdletBinding()]

--- a/FogApi/Public/Dismount-WinEfi.ps1
+++ b/FogApi/Public/Dismount-WinEfi.ps1
@@ -5,6 +5,11 @@ function Dismount-WinEfi {
         
         .DESCRIPTION
         Gets the efi partition mount letter and dismounts it with the mountvol tool
+
+        .EXAMPLE
+        Dismount-WinEfi
+
+        This example will dismount the efi partition if it is currently mounted
         
     #>
         

--- a/FogApi/Public/Enable-FogApiHTTPS.ps1
+++ b/FogApi/Public/Enable-FogApiHTTPS.ps1
@@ -5,6 +5,11 @@ function Enable-FogApiHTTPS {
     
     .DESCRIPTION
     Prepends https to the fogserver property of fog server settings
+
+    .EXAMPLE
+    Enable-FogApiHTTPS
+
+    This example will enforce https in the url used in all api calls by prepending https to the fogserver property of fog server settings
     
     #>
     [CmdletBinding()]

--- a/FogApi/Public/Get-FogGroupAssociations.ps1
+++ b/FogApi/Public/Get-FogGroupAssociations.ps1
@@ -7,10 +7,14 @@ function Get-FogGroupAssociations {
     Returns the objects in the groupassociations table
     
     .EXAMPLE
-    $groupAssocs = Get-FogGroupAssociations;
-    $groupAssocs | ? hostId -eq ((Get-FogHost).id)
+    Get-FogGroupAssociations | ? hostId -eq ((Get-FogHost).id)
     
-    Would give you the group associations of the current computer
+    Would give you the group associations filtered to the current computer
+
+    .EXAMPLE
+    Get-FogGroupAssociations;
+
+    This will return all group association objects in the fog database
 
     #>
     [CmdletBinding()]

--- a/FogApi/Public/Get-FogGroups.ps1
+++ b/FogApi/Public/Get-FogGroups.ps1
@@ -8,6 +8,8 @@ function Get-FogGroups {
     
     .EXAMPLE
     $groups = Get-FogGroups
+
+    This will return all the fog groups in the fog database and store them in the $groups variable
     
     .NOTES
     A group object does not contain membership information, you need to filter groupassociations to find membership

--- a/FogApi/Public/Get-FogHostMacs.ps1
+++ b/FogApi/Public/Get-FogHostMacs.ps1
@@ -13,7 +13,12 @@ function Get-FogHostMacs {
     .EXAMPLE
     Get-MacsForHost (Get-FogHost)
 
-    Will return the macs assigned to the computer running the command
+    Will return the macs assigned to the computer running the command utilizing the alias Get-MacsForHost for this command
+
+    .EXAMPLE
+    Get-FogHostMacs -hostID 1234
+
+    Will return the macs assigned to the host with the id of 1234
     
     #>
     [CmdletBinding()]

--- a/FogApi/Public/Get-FogInventory.ps1
+++ b/FogApi/Public/Get-FogInventory.ps1
@@ -75,7 +75,7 @@ function Get-FogInventory {
             if ($compSys.UUID -notmatch "12345678-9012-3456-7890-abcdefabcdef" ) {
                 $hostObj.inventory.sysuuid       = $compSys.UUID;
             } else {
-                $hostObj.inventory.sysuuid       = ($compSys.Qualifiers | Where-Object Name -match 'UUID' | Select-Object -ExpandProperty Value);
+                $hostObj.inventory.sysuuid       = ($compSys.CimInstanceProperties | Where-Object Name -match 'UUID' | Select-Object -ExpandProperty Value);
             }
             $hostObj.inventory.systype       = $case.chassistype; #device form factor found chassistype member of $case but it references a list that hasn't been updated anywhere I can find. i.e. returns 35 for a minipc but documented list only goes to 24
             $hostObj.inventory.biosversion   = $bios.name;

--- a/FogApi/Public/Get-FogModules.ps1
+++ b/FogApi/Public/Get-FogModules.ps1
@@ -7,8 +7,7 @@ function Get-FogModules {
     Returns the api module object. Can be utilized to find what modules are enabled by default when creating a new host
     
     .EXAMPLE
-    $mods = Get-FogModules
-    $mods
+    $mods = Get-FogModules; $mods
 
     Will put the list of modules in a variable and then display the list
     

--- a/FogApi/Public/Get-FogObject.ps1
+++ b/FogApi/Public/Get-FogObject.ps1
@@ -24,6 +24,11 @@ function Get-FogObject {
     This will get all hosts from the fog server.
     This will get all the hosts.
 
+    .EXAMPLE
+    Get-FogObject -type objectactivetasktype -coreActiveTaskObject task
+
+    This will get all the active tasks from the fog server which is in the objectactivetasktype type of object.
+
     
 #>
 

--- a/FogApi/Public/Get-FogSettings.ps1
+++ b/FogApi/Public/Get-FogSettings.ps1
@@ -5,6 +5,12 @@ function Get-FogSettings {
     
     .DESCRIPTION
     Returns all settings with their ids, names, values, and descriptions
+
+    .EXAMPLE
+    $settings = Get-FogSettings; $settings
+
+    Will put the list of settings in a variable and then display the list
+    You can then use the $settings object to filter for specific settings and their values, or to find the id of a setting to use in Set-FogSetting
     
     #>
     [CmdletBinding()]

--- a/FogApi/Public/Get-WinEfiMountLetter.ps1
+++ b/FogApi/Public/Get-WinEfiMountLetter.ps1
@@ -6,6 +6,11 @@ function Get-WinEfiMountLetter {
         .DESCRIPTION
         Runs the mountvol.exe tool and parses out the string at the end of the output
         that states if and where the EFI system partition is mounted
+
+        .EXAMPLE
+        Get-WinEfiMountLetter
+
+        This will return the current mount letter of the EFI partition if it is mounted, otherwise it will return null
         
     #>
         

--- a/FogApi/Public/Mount-WinEfi.ps1
+++ b/FogApi/Public/Mount-WinEfi.ps1
@@ -12,6 +12,11 @@ function Mount-WinEfi {
         
         .PARAMETER mountLtr
         The mount letter to use in A: format for mounting the EFI system partition
+
+        .EXAMPLE
+        Mount-WinEfi -mountLtr A:
+
+        This will mount the EFI system partition to A: if it is not already mounted there, it will utilize mountvol.exe
     
     #>
         

--- a/FogApi/Public/New-FogObject.ps1
+++ b/FogApi/Public/New-FogObject.ps1
@@ -15,6 +15,11 @@ json data in json string for api call
 .PARAMETER IDofObject
 the id of the object
 
+.EXAMPLE
+$hostID = 1234; $json = (@{"taskTypeID"='12';"deploySnapins"="-1";} | ConvertTo-Json); $result = New-FogObject -type objecttasktype -coreTaskObject host -jsonData $json -IDofObject "$hostID"; $result;
+
+Would create a new fog object of a start all snapins task. 
+
 #>
 
     [CmdletBinding()]

--- a/FogApi/Public/Remove-FogObject.ps1
+++ b/FogApi/Public/Remove-FogObject.ps1
@@ -15,6 +15,11 @@ json data in json string
 .PARAMETER IDofObject
 the id of the object
 
+.EXAMPLE
+$macs = get-fogmacaddresses; Remove-FogObject -type object -coreObject macaddressassociation -IDofObject $macs[-1].id;
+
+Would remove the last added mac address from the fog database
+
 #>
 
     [CmdletBinding()]

--- a/FogApi/Public/Repair-FogSnapinAssociations.ps1
+++ b/FogApi/Public/Repair-FogSnapinAssociations.ps1
@@ -12,16 +12,14 @@ function Repair-FogSnapinAssociations {
     Repair-FogSnapinAssociations
 
     'Example of output when there are associations to remove'
+    ```
     These snapin assoiciations have an invalid snapinID either of 0 or -1 or an id that doesn't belong to any snapins in the server and will be removed:
-
     id    hostID snapinID
     --    ------ --------
     9289  1809   0
     9985  1866   0
     10000 2091   0
-
     These snapin assoiciations have an invalid hostID of either 0 or -1 or other negative number, or have a hostid that doesn't belong to any host and will be removed:
-
     id   hostID snapinID
     --   ------ --------
     8281 1787   103
@@ -33,9 +31,9 @@ function Repair-FogSnapinAssociations {
     8601 1935   137
     9353 0      681
     9354 0      684
-
     Snapin Association repair complete!
-        
+    ```
+    
     .NOTES
     When running Get-FogHostAssociatedSnapins, if associations with invalid snapin ids are found, 
     #>

--- a/FogApi/Public/Reset-HostEncryption.ps1
+++ b/FogApi/Public/Reset-HostEncryption.ps1
@@ -12,23 +12,50 @@ function Reset-HostEncryption {
     .PARAMETER fogHost
     Defaults to getting current host or can pass a host object
 
+    .PARAMETER fogHostID
+    The fogHostID parameter allows you to pass a host ID to reset the encryption data for that host.
+
     .PARAMETER restartSvc
     The restartSvc switch will restart the fog service
     forcing a more immediate re-encryption and connection. This currently only works when used on the local computer
     you are resetting.
+
+    .EXAMPLE
+    Reset-HostEncryption -fogHostID 1234 -restartSvc
+
+    This example resets the encryption data for the host with ID 1234 and restarts the fog service to force a re-encryption.
+
+    .EXAMPLE
+    Reset-HostEncryption -fogHost (Get-FogHost -hostID 1234)
+
+    This example resets the encryption data for the host with ID 1234 using the host object returned from Get-FogHost.
+
+    .EXAMPLE
+    Reset-HostEncryption -restartSvc
+
+    This example resets the encryption data for the current host running the command and restarts the fog service to force a re-encryption.
     
 #>
     
     [CmdletBinding()]
+    [Alias('Reset-FogHostEncryption')]
     param (
-        [parameter(ValueFromPipeline=$true)]
+        [parameter(ValueFromPipeline=$true,ParameterSetName='HostObject')]
         $fogHost = (Get-FogHost),
+        [parameter(ParameterSetName='HostID')]
+        $fogHostID,
+        [parameter(ParameterSetName='HostObject')]
+        [parameter(ParameterSetName='HostID')]
         [switch]$restartSvc
      )
 
     process {
-        if ($null -ne $_) {
-            $fogHost = $_;
+        if ($PSCmdlet.ParameterSetName -eq 'HostID') {
+            $fogHost = Get-FogHost -hostID $fogHostID;
+        } else {
+            if ($null -ne $_) {
+                $fogHost = $_;
+            }
         }
         $fogHost.pub_key = "";
         $fogHost.sec_tok = "";

--- a/FogApi/Public/Resolve-HostID.ps1
+++ b/FogApi/Public/Resolve-HostID.ps1
@@ -9,6 +9,11 @@ function Resolve-HostID {
     .PARAMETER hostID
     the hostid to validate, if none is given, will get the host object of the current host
     
+    .EXAMPLE
+    Resolve-HostID -hostID 1234
+
+    This will return 1234 if it is a valid hostid and is an int with just numbers, otherwise it will return null
+
     #>
     [CmdletBinding()]
     param (

--- a/FogApi/Public/Set-FogHostImage.ps1
+++ b/FogApi/Public/Set-FogHostImage.ps1
@@ -12,6 +12,12 @@ function Set-FogHostImage {
     
     .PARAMETER fogImage
     the image object gotten from get-fogimages
+
+    .EXAMPLE
+    $foghost = get-foghost -hostid 1234; $imageName = 'MyImage'; $fogImages = Get-FogImages; $fogHost = Set-FogHostImage -hostId $fogHost.id -fogImage ($fogImages | Where-Object name -eq $imageName)
+
+    Will set the image with the name of MyImage to the host with the id of 1234
+
     
     #>
     [CmdletBinding()]

--- a/FogApi/Public/Set-FogInventory.ps1
+++ b/FogApi/Public/Set-FogInventory.ps1
@@ -12,6 +12,11 @@ the host object to set on
 .PARAMETER jsonData
 the jsondata with the inventory
 
+.EXAMPLE
+Set-FogInventory;
+
+Will set the inventory of the current hostr running the command to the json data gotten from get-foginventory
+
 
 #>
 

--- a/FogApi/Public/Set-FogServerSettings.ps1
+++ b/FogApi/Public/Set-FogServerSettings.ps1
@@ -33,6 +33,9 @@ This will set the current users FogApi/settings.json file to have the given api 
 "fog" as the server name for the uri in all api calls. These are of course example tokens and the actual tokens are much longer.
 
 .EXAMPLE
+Set-FogServerSettings -interactive
+
+This will prompt you for each setting and allow you to paste in the values for each setting, if you have issues with pasting into the prompts in linux, try again without -interactive and paste into each param. i.e. `Set-FogServerSettings -fogapiToken '12345abcdefg' -fogUserToken 'abcdefg12345' -fogServer 'fog'`
 
 #>
 

--- a/FogApi/Public/Set-FogServerSettingsFileSecurity.ps1
+++ b/FogApi/Public/Set-FogServerSettingsFileSecurity.ps1
@@ -8,6 +8,11 @@ function Set-FogServerSettingsFileSecurity {
     
     .PARAMETER settingsFile
     The settings file, defaults to the default path for the settings file tiy
+
+    .EXAMPLE
+    Set-FogServerSettingsFileSecurity;
+
+    Will set the permissions on the default settings file to full control for owner only, no access for anyone else
     
     .NOTES
     Has a try/catch on attempting to use set-acl in case permissions required aren't present on the current user in windows

--- a/FogApi/Public/Test-FogVerAbove1dot6.ps1
+++ b/FogApi/Public/Test-FogVerAbove1dot6.ps1
@@ -5,6 +5,11 @@ function Test-FogVerAbove1dot6 {
     
     .DESCRIPTION
     Tests if the version string matches 1.5 string, if it doesn't then it's likely above 1.6
+
+    .EXAMPLE
+    Test-FogVerAbove1dot6
+
+    This will return true if the fog version is above 1.6 and false if it is 1.5 or below
     
     .NOTES
     Could also make this a script scoped variable, but getting the version requires at least the fog server name


### PR DESCRIPTION
This pull request primarily improves the PowerShell cmdlet documentation for the FogApi module by adding or updating `.EXAMPLE` sections and clarifying usage instructions. Additionally, it introduces minor functional enhancements and corrections to parameter handling and output formatting.

**Documentation improvements:**

* Added or enhanced `.EXAMPLE` sections for many cmdlets including `Disable-FogApiHTTPS`, `Enable-FogApiHTTPS`, `Get-FogHostMacs`, `Get-FogGroupAssociations`, `Get-FogGroups`, `Get-FogModules`, `Get-FogSettings`, `Get-FogObject`, `New-FogObject`, `Remove-FogObject`, `Set-FogHostImage`, `Get-WinEfiMountLetter`, `Mount-WinEfi`, `Dismount-WinEfi`, `Resolve-HostID`, and `Reset-HostEncryption`, providing clearer usage instructions and sample invocations. [[1]](diffhunk://#diff-3025372fc9204260d2a06542cbca53702a9f308f8cfea8751fb73600db7aa2ccR9-R13) [[2]](diffhunk://#diff-e2491509e631a6233088c18cf053b04ca5da1dc4e4dd913eba72c483d03ead32R9-R13) [[3]](diffhunk://#diff-83925c1e55232d1bafc149c308031eb990fe50f414972766c05cdca11f9d218bL16-R21) [[4]](diffhunk://#diff-51a00f6509b25468672cf4110800314631bac8ef17513b3b4bc735c59475a622L10-R17) [[5]](diffhunk://#diff-81c0917823115b09b0f0c5e98f7d863e23b50fdd9750ee07f63fe6b52506c301R12-R13) [[6]](diffhunk://#diff-00c06ae6eedc228023171304fc782c80b9ca6da3d48bcaae7c4b8dc055e9a9b5L10-R10) [[7]](diffhunk://#diff-5fce1d6e92a3abd7d25dca59db74706d9776c014f285c7e9796bfcc347ad22b3R9-R14) [[8]](diffhunk://#diff-94286b013e640b2070c0f04892282f6ccf2144dd9584348974e62e2e8b28eb19R27-R31) [[9]](diffhunk://#diff-8b28632376fb28f211b09f36dc442b800ef411b7346ddd70b33948b3843e0561R18-R22) [[10]](diffhunk://#diff-86ac05d743b002837d73e975c0493f600e3e01261fbfa40eff77eddd8952221fR18-R22) [[11]](diffhunk://#diff-dd5b2bde8f37bc1a131eb79b7f588bbafd538e6939d2c0c284090f0454242af9R16-R21) [[12]](diffhunk://#diff-d77ff67af6fc28b555bf050e3b7ec8117a48efd427c94d4c994f9d56b76b3d9fR10-R14) [[13]](diffhunk://#diff-3d87f6df3a16eb5f7aea5808f1f91e43e9ec6495f17c6bce8e3100779c2a066aR16-R20) [[14]](diffhunk://#diff-3eae9f5de4021a426af028bb1752e535eb7516fad01b597ebe3ef62c5c312de9R9-R13) [[15]](diffhunk://#diff-f4ca8e3e9b699227aeec7668c4121dca21e247be592ffb7a565e409315c34143R12-R16) [[16]](diffhunk://#diff-dafc73c640f3126275d9869cb3f7ebf46088c8d91763567e2fa1f57e8643ba10R15-R59)

* Improved the formatting and clarity of example output in `Repair-FogSnapinAssociations` by enclosing sample output in code blocks and removing redundant blank lines. [[1]](diffhunk://#diff-ca1a394616f0c2f5539a84192a513997e54dd9e1608c55ba1af1c907305a0adaR15-L24) [[2]](diffhunk://#diff-ca1a394616f0c2f5539a84192a513997e54dd9e1608c55ba1af1c907305a0adaL36-R35)

**Functional and usability enhancements:**

* Updated `Reset-HostEncryption` to accept a new `fogHostID` parameter set, allowing users to reset encryption by host ID directly, and added related examples. The function now also includes an alias and improved parameter handling.

* In `Get-FogInventory`, replaced usage of the deprecated `Qualifiers` property with `CimInstanceProperties` to retrieve the system UUID, improving compatibility and reliability.

**Minor documentation consistency updates:**

* Streamlined and clarified example usages in `Approve-FogPendingMac` and `Deny-FogPendingMac` by combining command lines and improving readability. [[1]](diffhunk://#diff-9b62f200fb1cc2bc2e157be6e97a65368f286e57b113cd0f1b08760a90723562L22-R22) [[2]](diffhunk://#diff-0ffcd374b861cdcbd8e8973bef308b41fe35ef2862689cc5189c2ef038d6fb4fL19-R19)

These changes collectively enhance the user experience and maintainability of the FogApi module by making command usage more discoverable and improving code robustness.