### PR TITLE
Add group membership CRUD and group task/settings cmdlets

### DIFF
--- a/FogApi/FogApi.psd1
+++ b/FogApi/FogApi.psd1
@@ -113,28 +113,30 @@ PowerShellVersion = '5.1'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Add-FogHostMac', 'Add-FogResultData', 'Approve-FogPendingMac', 
-               'Deny-FogPendingMac', 'Disable-FogApiHTTPS', 'Dismount-WinEfi', 
-               'Enable-FogApiHTTPS', 'Find-FogObject', 'Get-FogActiveTasks', 
-               'Get-FogGroupAssociations', 'Get-FogGroupByName', 'Get-FogGroups', 
-               'Get-FogHost', 'Get-FogHostAssociatedSnapins', 'Get-FogHostGroup', 
-               'Get-FogHostMacs', 'Get-FogHostPendingMacs', 'Get-FogHosts', 
-               'Get-FogImages', 'Get-FogInventory', 'Get-FogLog', 
-               'Get-FogMacAddresses', 'Get-FogModules', 'Get-FogObject', 
-               'Get-FogScheduledTasks', 'Get-FogSecsSinceEpoch', 
-               'Get-FogServerSettings', 'Get-FogServerSettingsFile', 
-               'Get-FogSetting', 'Get-FogSettings', 'Get-FogSnapinAssociations', 
-               'Get-FogSnapins', 'Get-FogVersion', 'Get-LastImageTime', 
-               'Get-WinBcdPxeID', 'Get-WinEfiMountLetter', 'Install-FogService', 
-               'Invoke-FogApi', 'Mount-WinEfi', 'New-FogHost', 'New-FogObject', 
-               'Receive-FogImage', 'Remove-FogObject', 'Remove-UsbMac', 
-               'Repair-FogSnapinAssociations', 'Reset-HostEncryption', 
-               'Resolve-HostID', 'Send-FogImage', 'Send-FogWolTask', 
-               'Set-FogHostImage', 'Set-FogInventory', 'Set-FogServerSettings', 
-               'Set-FogServerSettingsFileSecurity', 'Set-FogSetting', 
-               'Set-FogSnapins', 'Set-WinToBootToPxe', 'Start-FogSnapin', 
-               'Start-FogSnapins', 'Test-FogVerAbove1dot6', 
-               'Test-StringNotNullOrEmpty', 'Update-FogObject'
+FunctionsToExport = 'Add-FogHostGroup', 'Add-FogHostMac', 'Add-FogResultData',
+               'Approve-FogPendingMac', 'Deny-FogPendingMac',
+               'Disable-FogApiHTTPS', 'Dismount-WinEfi', 'Enable-FogApiHTTPS',
+               'Find-FogObject', 'Get-FogActiveTasks',
+               'Get-FogGroupAssociations', 'Get-FogGroupByName', 'Get-FogGroups',
+               'Get-FogHost', 'Get-FogHostAssociatedSnapins', 'Get-FogHostGroup',
+               'Get-FogHostMacs', 'Get-FogHostPendingMacs', 'Get-FogHosts',
+               'Get-FogImages', 'Get-FogInventory', 'Get-FogLog',
+               'Get-FogMacAddresses', 'Get-FogModules', 'Get-FogObject',
+               'Get-FogScheduledTasks', 'Get-FogSecsSinceEpoch',
+               'Get-FogServerSettings', 'Get-FogServerSettingsFile',
+               'Get-FogSetting', 'Get-FogSettings', 'Get-FogSnapinAssociations',
+               'Get-FogSnapins', 'Get-FogVersion', 'Get-LastImageTime',
+               'Get-WinBcdPxeID', 'Get-WinEfiMountLetter', 'Install-FogService',
+               'Invoke-FogApi', 'Mount-WinEfi', 'New-FogHost', 'New-FogObject',
+               'Receive-FogImage', 'Remove-FogHostGroup', 'Remove-FogObject',
+               'Remove-UsbMac', 'Repair-FogSnapinAssociations',
+               'Reset-HostEncryption', 'Resolve-HostID', 'Send-FogGroupTask',
+               'Send-FogImage', 'Send-FogWolTask', 'Set-FogHostImage',
+               'Set-FogInventory', 'Set-FogServerSettings',
+               'Set-FogServerSettingsFileSecurity', 'Set-FogSetting',
+               'Set-FogSnapins', 'Set-WinToBootToPxe', 'Start-FogSnapin',
+               'Start-FogSnapins', 'Test-FogVerAbove1dot6',
+               'Test-StringNotNullOrEmpty', 'Update-FogGroup', 'Update-FogObject'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()
@@ -143,13 +145,14 @@ CmdletsToExport = @()
 VariablesToExport = @()
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = 'Add-FogHost', 'Add-FogObject', 'Add-FogSnapins', 'Capture-FogImage', 
-               'Deploy-FogImage', 'Get-FogAssociatedSnapins', 'Get-FogGroup', 
-               'Get-FogHostInventory', 'Get-FogHostSnapinAssociations', 
-               'Get-FogHostSnapins', 'Get-FogMacs', 'Get-MacsForHost', 
-               'Get-WinInventoryForFog', 'Invoke-FogImageCapture', 'Pull-FogImage', 
-               'Push-FogImage', 'Remove-FogMac', 'Reset-FogHostEncryption', 
-               'Save-FogImage', 'Set-FogObject'
+AliasesToExport = 'Add-FogGroupHost', 'Add-FogHost', 'Add-FogObject',
+               'Add-FogSnapins', 'Capture-FogImage', 'Deploy-FogImage',
+               'Get-FogAssociatedSnapins', 'Get-FogGroup', 'Get-FogHostInventory',
+               'Get-FogHostSnapinAssociations', 'Get-FogHostSnapins',
+               'Get-FogMacs', 'Get-MacsForHost', 'Get-WinInventoryForFog',
+               'Invoke-FogImageCapture', 'Pull-FogImage', 'Push-FogImage',
+               'Remove-FogGroupHost', 'Remove-FogMac', 'Reset-FogHostEncryption',
+               'Save-FogImage', 'Set-FogGroup', 'Set-FogObject'
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/FogApi/Public/Add-FogHostGroup.ps1
+++ b/FogApi/Public/Add-FogHostGroup.ps1
@@ -1,0 +1,67 @@
+function Add-FogHostGroup {
+<#
+    .SYNOPSIS
+    Adds a host to a fog group
+
+    .DESCRIPTION
+    Creates a group association entry linking a host to a group, adding the host as a member of that group.
+    Checks for an existing association first and skips creating a duplicate if the host is already a member of the group.
+
+    .PARAMETER fogHost
+    A fog host object (e.g. from Get-FogHost) to add to the group. Supports pipeline input.
+
+    .PARAMETER hostID
+    Can either be the id number of the host object or the name of the host in a string
+
+    .PARAMETER groupID
+    The id of the group to add the host to
+
+    .EXAMPLE
+    Add-FogHostGroup -hostID 1234 -groupID 5
+
+    Adds the host with id 1234 to the group with id 5
+
+    .EXAMPLE
+    Get-FogHost -hostname "computerName" | Add-FogHostGroup -groupID 5
+
+    Finds the host by name and adds it to the group with id 5
+
+#>
+
+    [CmdletBinding(DefaultParameterSetName='byHost')]
+    [Alias('Add-FogGroupHost')]
+    param (
+        [parameter(ValueFromPipeline=$true,ParameterSetName='byHost')]
+        $fogHost,
+        [parameter(ParameterSetName='byId')]
+        $hostID,
+        [parameter(Mandatory=$true,ParameterSetName='byHost')]
+        [parameter(Mandatory=$true,ParameterSetName='byId')]
+        $groupID
+    )
+
+    process {
+        if ($null -ne $_) {
+            $fogHost = $_;
+            $hostID = $fogHost.id;
+        }
+        $hostID = Resolve-HostID $hostID
+        if ($null -ne $hostID) {
+            $existingAssoc = Get-FogGroupAssociations | Where-Object { ($_.hostID -eq $hostID) -and ($_.groupID -eq $groupID) }
+            if ($null -ne $existingAssoc) {
+                Write-Warning "Host $hostID is already a member of group $groupID"
+                return $existingAssoc;
+            } else {
+                $newAssoc = @{
+                    hostID  = "$hostID"
+                    groupID = "$groupID"
+                }
+                return New-FogObject -type object -coreObject groupassociation -jsonData ($newAssoc | ConvertTo-Json)
+            }
+        } else {
+            Write-Error "provided hostid was invalid!"
+            return $null;
+        }
+    }
+
+}

--- a/FogApi/Public/Remove-FogHostGroup.ps1
+++ b/FogApi/Public/Remove-FogHostGroup.ps1
@@ -1,0 +1,62 @@
+function Remove-FogHostGroup {
+<#
+    .SYNOPSIS
+    Removes a host from a fog group
+
+    .DESCRIPTION
+    Finds the group association entry linking a host to a group and deletes it, removing the host from that group's membership.
+
+    .PARAMETER fogHost
+    A fog host object (e.g. from Get-FogHost) to remove from the group. Supports pipeline input.
+
+    .PARAMETER hostID
+    Can either be the id number of the host object or the name of the host in a string
+
+    .PARAMETER groupID
+    The id of the group to remove the host from
+
+    .EXAMPLE
+    Remove-FogHostGroup -hostID 1234 -groupID 5
+
+    Removes the host with id 1234 from the group with id 5
+
+    .EXAMPLE
+    Get-FogHost -hostname "computerName" | Remove-FogHostGroup -groupID 5
+
+    Finds the host by name and removes it from the group with id 5
+
+#>
+
+    [CmdletBinding(DefaultParameterSetName='byHost')]
+    [Alias('Remove-FogGroupHost')]
+    param (
+        [parameter(ValueFromPipeline=$true,ParameterSetName='byHost')]
+        $fogHost,
+        [parameter(ParameterSetName='byId')]
+        $hostID,
+        [parameter(Mandatory=$true,ParameterSetName='byHost')]
+        [parameter(Mandatory=$true,ParameterSetName='byId')]
+        $groupID
+    )
+
+    process {
+        if ($null -ne $_) {
+            $fogHost = $_;
+            $hostID = $fogHost.id;
+        }
+        $hostID = Resolve-HostID $hostID
+        if ($null -ne $hostID) {
+            $assoc = Get-FogGroupAssociations | Where-Object { ($_.hostID -eq $hostID) -and ($_.groupID -eq $groupID) }
+            if ($null -eq $assoc) {
+                Write-Warning "Host $hostID is not a member of group $groupID, nothing to remove"
+                return $null;
+            } else {
+                return Remove-FogObject -type object -coreObject groupassociation -IDofObject $assoc.id;
+            }
+        } else {
+            Write-Error "provided hostid was invalid!"
+            return $null;
+        }
+    }
+
+}

--- a/FogApi/Public/Send-FogGroupTask.ps1
+++ b/FogApi/Public/Send-FogGroupTask.ps1
@@ -1,0 +1,171 @@
+function Send-FogGroupTask {
+<#
+    .SYNOPSIS
+    Queues a task against every host in a fog group at once
+
+    .DESCRIPTION
+    Creates an immediate task (or, if -StartAtTime is given, a scheduled task) against a whole group of hosts in one call,
+    instead of looping New-FogObject/Send-FogImage per host.
+    Uses taskTypeID 1 (deploy) by default, the same default fog uses for a normal image deploy task.
+
+    .PARAMETER groupObj
+    A fog group object (e.g. from Get-FogGroups) to queue the task for. Supports pipeline input.
+
+    .PARAMETER groupID
+    The id of the group to queue the task for
+
+    .PARAMETER taskTypeID
+    The fog task type id to queue, defaults to 1 (deploy). See your fog server's task type list for other values (e.g. capture, memtest, etc.)
+
+    .PARAMETER StartAtTime
+    The time to start the task, use Get-date to create the required datetime object. If omitted the task is queued to start immediately.
+
+    .PARAMETER debugMode
+    Switch param to mark the task as a debug task. Only applies to immediate tasks.
+
+    .PARAMETER NoWol
+    Switch param to not use wake on lan in the task, default is to use wake on lan
+
+    .PARAMETER shutdown
+    Switch param to indicate hosts should shutdown at the end of the task instead of restarting.
+
+    .PARAMETER NoSnapins
+    Switch param for scheduled tasks, sets deploysnapins to false so assigned snapins aren't auto scheduled too. Only works in FOG 1.6+ and only with scheduled tasks.
+
+    .PARAMETER bypassbitlocker
+    Switch param to bypass bitlocker checks, this will set the bitlocker flag to 1 in the task, this is the 'other5' property.
+
+    .EXAMPLE
+    Send-FogGroupTask -groupID 5
+
+    Queues an immediate deploy task for every host in the group with id 5
+
+    .EXAMPLE
+    Get-FogGroupByName "Lab" | Send-FogGroupTask -StartAtTime (Get-Date 8pm)
+
+    Finds the group named "Lab" and schedules a deploy task for every host in it at 8pm today
+
+    .NOTES
+    Immediate group tasks use the "group" coreTaskObject (POST group/{id}/task), which is already a whitelisted call shape in this module.
+    Scheduled group tasks additionally set "isGroupTask":"1" and "groupID" instead of "hostID" in the scheduled task JSON, mirroring the
+    (currently always "0") isGroupTask field already present in Send-FogImage/Receive-FogImage. This scheduled-task path is inferred from
+    those whitelisted values and has not been exercised against a live fog server from within this module - verify it against your fog
+    server before relying on it in production.
+#>
+
+    [CmdletBinding()]
+    param (
+        [parameter(ValueFromPipeline=$true,ParameterSetName='byObj')]
+        $groupObj,
+        [parameter(Mandatory=$true,ParameterSetName='byId')]
+        $groupID,
+        $taskTypeID = 1,
+        [datetime]$StartAtTime,
+        [switch]$debugMode,
+        [switch]$NoWol,
+        [switch]$shutdown,
+        [switch]$NoSnapins,
+        [switch]$bypassbitlocker
+    )
+
+    process {
+        if ($null -ne $_) {
+            $groupObj = $_;
+        }
+        if ($null -ne $groupObj) {
+            $groupID = $groupObj.id;
+        }
+
+        $debugStr = "$($debugMode.IsPresent.toInt64($null))";
+        if ($NoWol) {
+            $wolStr = "0"
+        } else {
+            $wolStr = "1"
+        }
+        if ($shutdown) {
+            $shutdownStr = "1"
+        } else {
+            $shutdownStr = "0"
+        }
+        $bitlockerStr = "$($bypassbitlocker.IsPresent.ToInt64($null))";
+
+        if ($null -eq $StartAtTime) {
+            "Queuing an immediate task of type $taskTypeID for every host in group $groupID" | Out-Host;
+            if (Test-FogVerAbove1dot6) {
+                $jsonData = @"
+                {
+                    "taskName":"Group Task for group id $groupID",
+                    "taskTypeID":"$taskTypeID",
+                    "shutdown":"$shutdownStr",
+                    "debug":"$debugStr",
+                    "wol":"$wolStr",
+                    "isActive":"1"
+                }
+"@
+            } else {
+                $jsonData = @"
+                {
+                    "taskTypeID":"$taskTypeID",
+                    "shutdown":"$shutdownStr",
+                    "other2":"$debugStr",
+                    "other4":"$wolStr",
+                    "isActive":"1"
+                }
+"@
+            }
+            return New-FogObject -type objecttasktype -coreTaskObject group -jsonData $jsonData -IDofObject $groupID;
+        } else {
+            if ($NoSnapins) {
+                $deploySnapins = "0";
+            } else {
+                $deploySnapins = "-1";
+            }
+            "Scheduling a task of type $taskTypeID for every host in group $groupID to start at $StartAtTime" | Out-Host;
+            $scheduleTime = Get-FogSecsSinceEpoch -scheduleDate $StartAtTime
+            $runTime = Get-Date $StartAtTime -Format "yyyy-M-d HH:MM"
+            if (Test-FogVerAbove1dot6) {
+                $jsonData = @"
+                    {
+                        "taskName":"Group Task",
+                        "description":"Scheduled Group Task for group id $groupID on $($StartAtTime.DateTime.ToString())",
+                        "type":"S",
+                        "taskTypeID":"$taskTypeID",
+                        "runTime":"$runTime",
+                        "scheduleTime":"$scheduleTime",
+                        "isGroupTask":"1",
+                        "groupID":"$groupID",
+                        "shutdown":"$shutdownStr",
+                        "debug":"$debugStr",
+                        "wol":"$wolStr",
+                        "other2":"$deploySnapins",
+                        "other3":"API",
+                        "other4":"$wolStr",
+                        "other5":"$bitlockerStr",
+                        "isActive":"1",
+                        "deploySnapins":"$deploySnapins"
+                    }
+"@
+            } else {
+                $jsonData = @"
+                    {
+                        "name":"Group Task",
+                        "type":"S",
+                        "taskTypeID":"$taskTypeID",
+                        "runTime":"$runTime",
+                        "scheduleTime":"$scheduleTime",
+                        "isGroupTask":"1",
+                        "groupID":"$groupID",
+                        "shutdown":"$shutdownStr",
+                        "other2":"$deploySnapins",
+                        "other3":"API",
+                        "other4":"$wolStr",
+                        "other5":"$bitlockerStr",
+                        "isActive":"1"
+                    }
+"@
+            }
+            return New-FogObject -type object -coreObject scheduledtask -jsonData $jsonData;
+        }
+    }
+
+}

--- a/FogApi/Public/Send-FogGroupTask.ps1
+++ b/FogApi/Public/Send-FogGroupTask.ps1
@@ -46,11 +46,14 @@ function Send-FogGroupTask {
     Finds the group named "Lab" and schedules a deploy task for every host in it at 8pm today
 
     .NOTES
-    Immediate group tasks use the "group" coreTaskObject (POST group/{id}/task), which is already a whitelisted call shape in this module.
-    Scheduled group tasks additionally set "isGroupTask":"1" and "groupID" instead of "hostID" in the scheduled task JSON, mirroring the
-    (currently always "0") isGroupTask field already present in Send-FogImage/Receive-FogImage. This scheduled-task path is inferred from
-    those whitelisted values and has not been exercised against a live fog server from within this module - verify it against your fog
-    server before relying on it in production.
+    Verified against the fog server source (FOGProject/fogproject, working-1.6 branch, packages/web/lib/router/route.class.php and
+    packages/web/lib/fog/scheduledtask.class.php):
+    - Immediate group tasks use the "group" coreTaskObject (POST group/{id}/task), routed to Route::task() which calls
+      Group::createImagePackage() when the target class is a Group. Reads taskTypeID, taskName, shutdown, debug, wol, deploySnapins.
+    - Scheduled group tasks go through the generic scheduledtask create() route. The scheduledtask table has no separate groupID column -
+      "isGroupTask":"1" instead repurposes the "hostID" field (db column stGroupHostID) to hold the group id, so this cmdlet sends
+      "hostID":"$groupID" rather than a "groupID" field. The scheduledtask create route only maps JSON keys that literally match its
+      databaseFields, so the task's name field must be sent as "name", not "taskName".
 #>
 
     [CmdletBinding()]
@@ -126,14 +129,14 @@ function Send-FogGroupTask {
             if (Test-FogVerAbove1dot6) {
                 $jsonData = @"
                     {
-                        "taskName":"Group Task",
+                        "name":"Group Task",
                         "description":"Scheduled Group Task for group id $groupID on $($StartAtTime.DateTime.ToString())",
                         "type":"S",
                         "taskTypeID":"$taskTypeID",
                         "runTime":"$runTime",
                         "scheduleTime":"$scheduleTime",
                         "isGroupTask":"1",
-                        "groupID":"$groupID",
+                        "hostID":"$groupID",
                         "shutdown":"$shutdownStr",
                         "debug":"$debugStr",
                         "wol":"$wolStr",
@@ -154,7 +157,7 @@ function Send-FogGroupTask {
                         "runTime":"$runTime",
                         "scheduleTime":"$scheduleTime",
                         "isGroupTask":"1",
-                        "groupID":"$groupID",
+                        "hostID":"$groupID",
                         "shutdown":"$shutdownStr",
                         "other2":"$deploySnapins",
                         "other3":"API",

--- a/FogApi/Public/Set-FogServerSettings.ps1
+++ b/FogApi/Public/Set-FogServerSettings.ps1
@@ -12,9 +12,12 @@ and keeps the settings from being overwritten when updating the module
 
 .PARAMETER fogApiToken
 fog API token is found at https://fog-server/fog/management/index.php?node=about&sub=settings under API System
+Copy the token exactly as displayed in the web ui; it is shown base64-encoded and that is the form the fog api expects in the request header
+(the server base64-decodes it before comparing). Do not use the raw token value from the fog database, it will fail with a 403.
 
 .PARAMETER fogUserToken
 your fog user api token found in the user settings https://fog-server/fog/management/index.php?node=user&sub=list select your api enabled used and view the api tab
+Copy this token exactly as displayed in the web ui too; like the api token it is shown base64-encoded, which is the form the api expects.
 
 .PARAMETER fogServer
 your fog server hostname or ip address to be used for created the url used in api calls default is fog-server or fogServer

--- a/FogApi/Public/Update-FogGroup.ps1
+++ b/FogApi/Public/Update-FogGroup.ps1
@@ -4,28 +4,86 @@ function Update-FogGroup {
     Updates a fog group's own fields
 
     .DESCRIPTION
-    Edits the group object itself (e.g. name, description) rather than its host membership.
-    Use Add-FogHostGroup/Remove-FogHostGroup to manage which hosts belong to a group.
+    Edits the group object itself (name, description, kernel options, etc.) rather than its host membership.
+    Use Add-FogHostGroup/Remove-FogHostGroup to add or remove a single host at a time.
+
+    You can either:
+    - Pipe in a group object (e.g. from Get-FogGroups/Get-FogGroupByName), change its properties directly, and
+      pipe the modified object back in - the changed scalar fields (name, description, building, kernel,
+      kernelArgs, kernelDevice, init) are sent automatically.
+    - Use the named parameters below directly against -groupID or a piped group object. Named parameters always
+      take precedence over whatever is present on a piped object.
 
     .PARAMETER groupObj
-    A fog group object (e.g. from Get-FogGroups) to update. Supports pipeline input.
+    A fog group object (e.g. from Get-FogGroups) to update. Supports pipeline input. Its own name/description/
+    building/kernel/kernelArgs/kernelDevice/init properties are sent as-is unless overridden by a named parameter.
 
     .PARAMETER groupID
     The id of the group to update
 
+    .PARAMETER Name
+    The group's name
+
+    .PARAMETER Description
+    The group's description
+
+    .PARAMETER Building
+    The building associated with the group
+
+    .PARAMETER Kernel
+    The kernel file name to use for hosts in this group
+
+    .PARAMETER KernelArgs
+    The kernel arguments to use for hosts in this group
+
+    .PARAMETER KernelDevice
+    The primary disk/device to use for hosts in this group
+
+    .PARAMETER Init
+    The init/initrd setting for hosts in this group
+
+    .PARAMETER Hosts
+    Full replacement list of host ids that should be members of this group. Fog diffs this against the group's
+    current membership and adds/removes hosts accordingly. For adding/removing a single host, prefer
+    Add-FogHostGroup/Remove-FogHostGroup instead.
+
+    .PARAMETER Snapins
+    Full replacement list of snapin ids to associate with every host currently in this group
+
+    .PARAMETER Printers
+    Full replacement list of printer ids to associate with every host currently in this group
+
+    .PARAMETER Modules
+    Full replacement list of module ids to associate with every host currently in this group
+
+    .PARAMETER ImageID
+    Assigns this image id to every host currently in this group. Fails if any member host is currently mid-task.
+
     .PARAMETER settings
-    A hashtable of the group fields to change, e.g. @{name="NewName"; description="New description"}
+    Escape hatch: a hashtable of any additional group fields to change, sent alongside/underneath the named
+    parameters above. Useful for fields not otherwise exposed as a named parameter.
 
     .EXAMPLE
-    Update-FogGroup -groupID 5 -settings @{description="Lab computers"}
+    Update-FogGroup -groupID 5 -Description "Lab computers"
 
     Updates the description field of the group with id 5
 
     .EXAMPLE
-    Get-FogGroupByName "Lab" | Update-FogGroup -settings @{name="Lab Computers"}
+    $g = Get-FogGroupByName "Lab"; $g.description = "Lab Computers"; $g | Update-FogGroup
 
-    Finds the group named "Lab" and renames it to "Lab Computers"
+    Gets the group named "Lab", edits its description property directly on the returned object, and sends the
+    change back with the modified object piped straight into Update-FogGroup.
 
+    .EXAMPLE
+    Get-FogGroupByName "Lab" | Update-FogGroup -ImageID 12
+
+    Finds the group named "Lab" and assigns image id 12 to every host currently in that group.
+
+    .NOTES
+    Verified against the fog server source (FOGProject/fogproject, working-1.6 and dev-branch, identical on
+    both): Group's databaseFields are name/description/createdBy/createdTime/building/kernel/kernelArgs/
+    kernelDevice/init (only "name" is required), and the group edit route additionally special-cases
+    hosts/snapins/printers/modules/imageID to cascade the change to every member host.
 #>
 
     [CmdletBinding(DefaultParameterSetName='byId')]
@@ -35,8 +93,18 @@ function Update-FogGroup {
         $groupObj,
         [parameter(Mandatory=$true,ParameterSetName='byId')]
         $groupID,
-        [parameter(Mandatory=$true,ParameterSetName='byObj')]
-        [parameter(Mandatory=$true,ParameterSetName='byId')]
+        [string]$Name,
+        [string]$Description,
+        [string]$Building,
+        [string]$Kernel,
+        [string]$KernelArgs,
+        [string]$KernelDevice,
+        [string]$Init,
+        [int[]]$Hosts,
+        [int[]]$Snapins,
+        [int[]]$Printers,
+        [int[]]$Modules,
+        [int]$ImageID,
         [hashtable]$settings
     )
 
@@ -47,8 +115,42 @@ function Update-FogGroup {
         if ($null -ne $groupObj) {
             $groupID = $groupObj.id;
         }
-        $jsonData = ($settings | ConvertTo-Json);
-        return Update-FogObject -type object -coreObject group -IDofObject $groupID -jsonData $jsonData
+
+        $fields = @{};
+
+        if ($null -ne $settings) {
+            foreach ($key in $settings.Keys) {
+                $fields[$key] = $settings[$key];
+            }
+        }
+
+        if ($null -ne $groupObj) {
+            foreach ($prop in @('name', 'description', 'building', 'kernel', 'kernelArgs', 'kernelDevice', 'init')) {
+                if ($null -ne $groupObj.$prop) {
+                    $fields[$prop] = $groupObj.$prop;
+                }
+            }
+        }
+
+        if ($PSBoundParameters.ContainsKey('Name')) { $fields['name'] = $Name }
+        if ($PSBoundParameters.ContainsKey('Description')) { $fields['description'] = $Description }
+        if ($PSBoundParameters.ContainsKey('Building')) { $fields['building'] = $Building }
+        if ($PSBoundParameters.ContainsKey('Kernel')) { $fields['kernel'] = $Kernel }
+        if ($PSBoundParameters.ContainsKey('KernelArgs')) { $fields['kernelArgs'] = $KernelArgs }
+        if ($PSBoundParameters.ContainsKey('KernelDevice')) { $fields['kernelDevice'] = $KernelDevice }
+        if ($PSBoundParameters.ContainsKey('Init')) { $fields['init'] = $Init }
+        if ($PSBoundParameters.ContainsKey('Hosts')) { $fields['hosts'] = $Hosts }
+        if ($PSBoundParameters.ContainsKey('Snapins')) { $fields['snapins'] = $Snapins }
+        if ($PSBoundParameters.ContainsKey('Printers')) { $fields['printers'] = $Printers }
+        if ($PSBoundParameters.ContainsKey('Modules')) { $fields['modules'] = $Modules }
+        if ($PSBoundParameters.ContainsKey('ImageID')) { $fields['imageID'] = $ImageID }
+
+        if ($fields.Count -eq 0) {
+            Write-Warning "No group fields were provided to update - nothing to do"
+            return $null;
+        }
+
+        return Update-FogObject -type object -coreObject group -IDofObject $groupID -jsonData ($fields | ConvertTo-Json)
     }
 
 }

--- a/FogApi/Public/Update-FogGroup.ps1
+++ b/FogApi/Public/Update-FogGroup.ps1
@@ -1,0 +1,54 @@
+function Update-FogGroup {
+<#
+    .SYNOPSIS
+    Updates a fog group's own fields
+
+    .DESCRIPTION
+    Edits the group object itself (e.g. name, description) rather than its host membership.
+    Use Add-FogHostGroup/Remove-FogHostGroup to manage which hosts belong to a group.
+
+    .PARAMETER groupObj
+    A fog group object (e.g. from Get-FogGroups) to update. Supports pipeline input.
+
+    .PARAMETER groupID
+    The id of the group to update
+
+    .PARAMETER settings
+    A hashtable of the group fields to change, e.g. @{name="NewName"; description="New description"}
+
+    .EXAMPLE
+    Update-FogGroup -groupID 5 -settings @{description="Lab computers"}
+
+    Updates the description field of the group with id 5
+
+    .EXAMPLE
+    Get-FogGroupByName "Lab" | Update-FogGroup -settings @{name="Lab Computers"}
+
+    Finds the group named "Lab" and renames it to "Lab Computers"
+
+#>
+
+    [CmdletBinding(DefaultParameterSetName='byId')]
+    [Alias('Set-FogGroup')]
+    param (
+        [parameter(ValueFromPipeline=$true,ParameterSetName='byObj')]
+        $groupObj,
+        [parameter(Mandatory=$true,ParameterSetName='byId')]
+        $groupID,
+        [parameter(Mandatory=$true,ParameterSetName='byObj')]
+        [parameter(Mandatory=$true,ParameterSetName='byId')]
+        [hashtable]$settings
+    )
+
+    process {
+        if ($null -ne $_) {
+            $groupObj = $_;
+        }
+        if ($null -ne $groupObj) {
+            $groupID = $groupObj.id;
+        }
+        $jsonData = ($settings | ConvertTo-Json);
+        return Update-FogObject -type object -coreObject group -IDofObject $groupID -jsonData $jsonData
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ in notepad on windows, nano on linux, or TextEdit on Mac
 You can also open the settings.json file and edit it manually before running your first command, but it's best to use the `Set-FogServerSettings -interactive` function and switch for first time setup.
 The default settings in `settings.json` are explanations of where to find the proper settings since json can't have comments
 
+Note: copy each api token exactly as displayed in the fog web ui. The ui displays the tokens base64-encoded and that encoded form is what the fog api expects in the request headers (the server base64-decodes them before comparing, and has since the api was introduced in fog 1.5). If you pull a token straight from the fog database instead, api calls will fail with a 403 until you base64-encode it.
+
 Once the settings are set you can have a jolly good time utilizing the fog documentation
 found here https://news.fogproject.org/simplified-api-documentation/ that was used to model the parameters
 


### PR DESCRIPTION
## Summary
- Adds `Add-FogHostGroup` (alias `Add-FogGroupHost`) to add a host to a group, and `Remove-FogHostGroup` (alias `Remove-FogGroupHost`) to remove a host from a group, via the existing `groupassociation` REST object — modeled on `Add-FogHostMac`/`Deny-FogPendingMac`.
- Adds `Update-FogGroup` (alias `Set-FogGroup`) with named parameters for every real group field (`Name`, `Description`, `Building`, `Kernel`, `KernelArgs`, `KernelDevice`, `Init`, `Hosts`, `Snapins`, `Printers`, `Modules`, `ImageID`) for tab-completable discoverability, plus support for piping in a group object (e.g. from `Get-FogGroups`), editing its scalar properties directly, and passing it straight back in. A `-settings` hashtable remains as an escape hatch.
- Adds `Send-FogGroupTask` to queue an immediate or scheduled task against every host in a group at once, modeled on `Send-FogImage`.
- Updates `FogApi.psd1`'s `FunctionsToExport`/`AliasesToExport` alphabetically for the new functions/aliases.
- Documents in `Set-FogServerSettings` help and the README that the FOG web UI displays API tokens base64-encoded and that this is exactly the form the API expects in the headers (see "API token research" below).

Closes #28

## Verification: tested against a real, live FOG server
Beyond static/source verification, I stood up a real FOG instance (MariaDB + Apache + PHP, schema deployed, cloned from `FOGProject/fogproject` working-1.6) and exercised all 4 new cmdlets against actual REST responses:
- `Add-FogHostGroup`: created a real `groupassociation` row; group's `hostcount` correctly went from 0→1; re-running against the same host/group correctly detected the duplicate and warned instead of erroring.
- `Update-FogGroup`: verified both usage patterns — named parameters (`-Description`, `-Kernel`) persisted correctly, and the "`Get-FogGroups` → edit `.description` on the object → pipe it back in" pattern also persisted correctly.
- `Send-FogGroupTask` (immediate): reached `Group::createImagePackage()` on the server with no errors.
- `Send-FogGroupTask` (scheduled): the earlier source-review fix (`hostID` reuse + `"name"` not `"taskName"`) is confirmed live — the server's response included a correctly-resolved nested `"group":{...}` object, which only resolves when `hostID`/`isGroupTask` are set correctly.
- `Remove-FogHostGroup`: removed the association; `Get-FogHostGroup` confirmed membership was gone; re-running against a non-member correctly warned instead of erroring.

Test host/group/scheduled-task records were cleaned up afterward.

### API token research (resolves the earlier "base64 discovery" flagged here)
An earlier revision of this PR body flagged that this server snapshot's API auth `base64_decode`s the `fog-api-token`/`fog-user-token` headers, and wondered whether the module needed changes. Researched against the full fogproject git history and both branches — **it is long-standing intended behavior, not a recent 1.6 change, and no module change is needed**:
- `Route::_testToken()` has base64-decoded the header since the commit that created `route.class.php` (`408f062b2`, 2017-04-08); `_testAuth()`'s user-token decode followed in `4e8810ccd` (2017-04-22). Identical on `stable` (1.5.x) and `working-1.6`.
- It's a deliberate round-trip: the DB stores the raw 128-char hex token, but the web UI *displays* both tokens `base64_encode`d (settings page + user API tab, both branches) and decodes on save. What admins copy from the GUI — which is exactly where this module's setup instructions point — is already the base64 form the server expects. FOG's official docs confirm: "The web UI already displays both tokens base64-encoded, which is exactly the form the server expects in the header."
- Recent working-1.6 commits only made the compare timing-safe (`hash_equals`, `63adf1cac`) and added role binding (`edceb2c9f`) — no format change (`git log -S'base64_decode'` since 2025 is empty).
- The live test above only hit 403s initially because the tokens were pulled as raw hex straight from the database, bypassing the GUI's encoding. `Invoke-FogApi.ps1` is correct as-is; this PR adds a short note to `Set-FogServerSettings` help + README so the "raw DB token → 403" pitfall is documented.

## Notes / limitations
- The repo's build script (`invoke-modulebuild.ps1`) is Windows-oriented (relies on PowerShell's `mkdir` alias, not available the same way on Linux) and couldn't be run in this Linux environment; this matches the existing CI setup which only builds on `windows-latest`.
- No Pester tests exist in this repo yet (`Tests/placeholder.md`), consistent with existing project conventions.

## Test plan
- [x] `Test-ModuleManifest` passes against `FogApi/FogApi.psd1`
- [x] `Import-Module` succeeds and all new functions/aliases are present via `Get-Command -Module FogApi`
- [x] `Get-Help` succeeds for each new cmdlet
- [x] Request field names/shapes cross-checked against FOG server source (`working-1.6` and `dev-branch`, identical)
- [x] Exercised against a live FOG server: create/add/remove/update/task all confirmed working end-to-end
- [x] API token base64 handling researched across full git history and both branches; docs note added, no code change needed
